### PR TITLE
機屋のCRUD機能を作成_v1

### DIFF
--- a/app/controllers/user/home_controller.rb
+++ b/app/controllers/user/home_controller.rb
@@ -1,0 +1,6 @@
+class User::HomeController < ApplicationController
+  def index
+    # ログイン機能が未実装のため、すべての受注を取得
+    @orders = Order.all
+  end
+end

--- a/app/controllers/user/machines_controller.rb
+++ b/app/controllers/user/machines_controller.rb
@@ -1,0 +1,52 @@
+class User::MachinesController < ApplicationController
+  include ApplicationHelper
+  before_action :set_machine, only: [ :show, :edit, :update, :destroy ]
+
+  def index
+    @machines = Machine.all
+    @work_processes = WorkProcess.all
+  end
+
+  def show
+    @work_processes = @machine.work_processes.all
+  end
+
+  def new
+    @machine = Machine.new
+  end
+
+  def create
+    @machine = Machine.new(machine_params)
+    if @machine.save
+      redirect_to user_machine_path(@machine), notice: "織機が作成されました。"
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @machine.update(machine_params)
+      redirect_to user_machines_path, notice: "織機が更新されました。"
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @machine.destroy
+    redirect_to user_machines_path, status: :see_other, notice: "織機が削除されました。"
+  end
+
+  private
+
+  def set_machine
+    @machine = Machine.find(params[:id])
+  end
+
+  def machine_params
+    params.require(:machine).permit(:name, :machine_type_id, :company_id)
+  end
+end

--- a/app/controllers/user/orders_controller.rb
+++ b/app/controllers/user/orders_controller.rb
@@ -1,0 +1,94 @@
+class User::OrdersController < ApplicationController
+  include ApplicationHelper
+  before_action :set_order, only: [ :show, :edit, :update, :destroy ]
+
+  def index
+    @orders = Order.all
+  end
+
+  def show
+    @work_processes = @order.work_processes.includes(:work_process_definition, machine_assignments: :machine)
+    @current_work_process = find_current_work_process(@order.work_processes)
+
+    if @current_work_process
+      @current_machine_assignments = @current_work_process.machine_assignments.includes(:machine)
+      @machines = @current_machine_assignments.map(&:machine).uniq
+    else
+      @current_machine_assignments = []
+      @machines = []
+    end
+  end
+
+  def new
+    @order = Order.new
+    @order.work_processes.build
+  end
+
+  def create
+    @order = Order.new(order_params)
+    if @order.save
+      redirect_to user_order_path(@order), status: :unprocessable_entity, notice: "受注が正常に作成されました。"
+    else
+      render :new
+    end
+  end
+
+  def edit
+    @order.work_processes.build if @order.work_processes.empty?
+  end
+
+  def update
+    ActiveRecord::Base.transaction do
+      if @order.update(order_params)
+        update_related_models
+        redirect_to user_order_path(@order), status: :unprocessable_entity, notice: "受注情報が更新されました。"
+      else
+        render :edit
+      end
+    end
+  rescue ActiveRecord::UnknownAttributeError => e
+    render :edit, alert: "更新中にエラーが発生しました: #{e.message}"
+  end
+
+  def destroy
+    @order.destroy
+    redirect_to user_orders_path, status: :see_other, notice: "受注が削除されました。"
+  end
+
+  private
+
+  def set_order
+    @order = Order.find(params[:id])
+  end
+
+  def order_params
+    params.require(:order).permit(
+      :company_id,
+      :product_number_id,
+      :color_number_id,
+      :roll_count,
+      :quantity,
+      :start_date
+    )
+  end
+
+  def update_related_models
+    # work_process_definition_id と work_process_status_id を更新
+    if params[:order][:work_process_definition_id].present? || params[:order][:work_process_status_id].present?
+      work_process = @order.work_processes.first
+      work_process.update(
+        work_process_definition_id: params[:order][:work_process_definition_id],
+        work_process_status_id: params[:order][:work_process_status_id]
+      ) if work_process
+    end
+
+    # machine_id と machine_status_id を更新
+    if params[:order][:machine_id].present? || params[:order][:machine_status_id].present?
+      machine_assignment = @order.machine_assignments.first
+      machine_assignment.update(
+        machine_id: params[:order][:machine_id],
+        machine_status_id: params[:order][:machine_status_id]
+      ) if machine_assignment
+    end
+  end
+end

--- a/app/controllers/user/users_controller.rb
+++ b/app/controllers/user/users_controller.rb
@@ -1,0 +1,25 @@
+class User::UsersController < ApplicationController
+  def show
+    # デモ用に最初のユーザーを取得
+    @user = User.first
+  end
+
+  def edit
+    @user = User.first
+  end
+
+  def update
+    @user = User.first
+    if @user.update(user_params)
+      redirect_to user_user_path(@user), notice: 'ユーザー情報が更新されました。'
+    else
+      render :edit
+    end
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:name, :email, :phone_number)
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,18 @@
 module ApplicationHelper
+  # 現在作業中の作業工程を取得するヘルパーメソッド
+  def find_current_work_process(work_processes)
+    # 「作業完了」ステータスの最新の作業工程を取得
+    latest_completed_wp = work_processes.joins(:work_process_status)
+                                        .where(work_process_statuses: { name: '作業完了' })
+                                        .order(start_date: :desc)
+                                        .first
+    if latest_completed_wp
+      # 最新の「作業完了」より後の作業工程を取得
+      next_process = work_processes.where('start_date > ?', latest_completed_wp.start_date).order(:start_date).first
+      next_process
+    else
+      # 「作業完了」がない場合、最も古い作業工程を取得
+      work_processes.order(:start_date).first
+    end
+  end
 end

--- a/app/helpers/user/home_helper.rb
+++ b/app/helpers/user/home_helper.rb
@@ -1,0 +1,2 @@
+module User::HomeHelper
+end

--- a/app/helpers/user/machines_helper.rb
+++ b/app/helpers/user/machines_helper.rb
@@ -1,0 +1,2 @@
+module User::MachinesHelper
+end

--- a/app/helpers/user/orders_helper.rb
+++ b/app/helpers/user/orders_helper.rb
@@ -1,0 +1,2 @@
+module User::OrdersHelper
+end

--- a/app/helpers/user/users_helper.rb
+++ b/app/helpers/user/users_helper.rb
@@ -1,0 +1,2 @@
+module User::UsersHelper
+end

--- a/app/models/machine.rb
+++ b/app/models/machine.rb
@@ -2,4 +2,5 @@ class Machine < ApplicationRecord
   belongs_to :machine_type
   belongs_to :company
   has_many :machine_assignments
+  has_many :work_processes, through: :machine_assignments
 end

--- a/app/models/work_process.rb
+++ b/app/models/work_process.rb
@@ -4,4 +4,5 @@ class WorkProcess < ApplicationRecord
   belongs_to :work_process_definition
   belongs_to :work_process_status
   has_many :machine_assignments
+  has_many :machines, through: :machine_assignments
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,23 +1,26 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <title><%= content_for(:title) || "Loom Management" %></title>
-    <meta name="viewport" content="width=device-width,initial-scale=1">
-    <meta name="apple-mobile-web-app-capable" content="yes">
-    <%= csrf_meta_tags %>
-    <%= csp_meta_tag %>
+<head>
+  <title>アプリケーション名</title>
+  <%= csrf_meta_tags %>
+  <%= csp_meta_tag %>
 
-    <%= yield :head %>
+  <%= stylesheet_link_tag 'application', media: 'all' %>
+  <%= javascript_include_tag 'application' %>
+  <%= javascript_include_tag "turbo", type: "module" %>
+</head>
+<body>
+  <header>
+    <nav>
+      <ul>
+        <li><%= link_to 'ホーム', user_root_path %></li>
+        <li><%= link_to 'ユーザー情報', user_user_path(User.first) %></li>
+        <li><%= link_to '織機一覧', user_machines_path %></li>
+        <li><%= link_to '受注管理', user_orders_path %></li>
+      </ul>
+    </nav>
+  </header>
 
-    <link rel="manifest" href="/manifest.json">
-    <link rel="icon" href="/icon.png" type="image/png">
-    <link rel="icon" href="/icon.svg" type="image/svg+xml">
-    <link rel="apple-touch-icon" href="/icon.png">
-    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
-    <%= javascript_importmap_tags %>
-  </head>
-
-  <body>
-    <%= yield %>
-  </body>
+  <%= yield %>
+</body>
 </html>

--- a/app/views/user/home/index.html.erb
+++ b/app/views/user/home/index.html.erb
@@ -1,0 +1,32 @@
+<h1>ホーム画面</h1>
+
+<h2>受注管理</h2>
+
+<table>
+    <thead>
+        <tr>
+        <th>ID</th>
+        <th>会社名</th>
+        <th>品番</th>
+        <th>色番</th>
+        <th>数量</th>
+        <th>開始日</th>
+        <th>詳細</th>
+        </tr>
+    </thead>
+    <tbody>
+        <% @orders.each do |order| %>
+        <tr>
+            <td><%= order.id %></td>
+            <td><%= order.company&.name %></td>
+            <td><%= order.product_number&.number %></td>
+            <td><%= order.color_number&.color_code %></td>
+            <td><%= order.quantity %></td>
+            <td><%= order.start_date %></td>
+            <td><%= link_to '詳細', user_order_path(order) %></td>
+            <td><%= link_to '編集', edit_user_order_path(order) %></td>
+            <td><%= link_to '戻る', user_root_path %></td>
+        </tr>
+        <% end %>
+    </tbody>
+</table>

--- a/app/views/user/machines/_form.html.erb
+++ b/app/views/user/machines/_form.html.erb
@@ -1,0 +1,31 @@
+<%= form_with(model: [:user, @machine], local: true) do |form| %>
+    <% if @machine.errors.any? %>
+        <div class="alert alert-danger">
+        <h4><%= pluralize(@machine.errors.count, "error") %> prohibited this machine from being saved:</h4>
+        <ul>
+            <% @machine.errors.full_messages.each do |message| %>
+            <li><%= message %></li>
+            <% end %>
+        </ul>
+        </div>
+    <% end %>
+
+    <div class="form-group">
+        <%= form.label :name, "織機名:" %>
+        <%= form.text_field :name, class: "form-control" %>
+    </div>
+
+    <div class="form-group">
+        <%= form.label :machine_type_id, "織機のタイプ:" %>
+        <%= form.collection_select :machine_type_id, MachineType.all, :id, :name, { prompt: "Select Machine Type" }, { class: "form-control" } %>
+    </div>
+
+    <div class="form-group">
+        <%= form.label :company_id, "会社名:" %>
+        <%= form.collection_select :company_id, Company.all, :id, :name, { prompt: "Select Company" }, { class: "form-control" } %>
+    </div>
+
+    <div class="actions">
+        <%= form.submit '更新', class: "btn btn-primary" %>
+    </div>
+<% end %>

--- a/app/views/user/machines/edit.html.erb
+++ b/app/views/user/machines/edit.html.erb
@@ -1,0 +1,5 @@
+<h1>織機の編集</h1>
+
+<%= render 'form' %>
+
+<%= link_to '戻る', user_machine_path(@machine), class: "btn btn-secondary" %>

--- a/app/views/user/machines/index.html.erb
+++ b/app/views/user/machines/index.html.erb
@@ -1,0 +1,49 @@
+<h1>織機一覧</h1>
+
+<%= link_to '新規織機追加', new_user_machine_path %>
+
+<table>
+    <thead>
+        <tr>
+            <th>織機名</th>
+            <th>品番</th>
+            <th>現在の作業工程</th>
+            <th>ステータス</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+        <% @machines.each do |machine| %>
+        <% current_wp = find_current_work_process(machine.work_processes) %>
+        <tr>
+            <td><%= machine.name %></td>
+            <td>
+                <% if current_wp && current_wp.order %>
+                    <%= current_wp.order.product_number.number %>
+                <% else %>
+                    N/A
+                <% end %>
+            </td>
+            <td>
+                <% if current_wp && current_wp.work_process_definition %>
+                    <%= current_wp.work_process_definition.name %>
+                <% else %>
+                    N/A
+                <% end %>
+            </td>
+            <td>
+                <% if current_wp && current_wp.work_process_status %>
+                    <%= current_wp.work_process_status.name %>
+                <% else %>
+                    N/A
+                <% end %>
+            </td>
+            <td>
+                <%= link_to '詳細', user_machine_path(machine) %>
+                <%= link_to '編集', edit_user_machine_path(machine) %>
+                <%= link_to '削除', user_machine_path(machine), data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか？' }, class: "btn btn-danger btn-sm" %>
+            </td>
+        </tr>
+        <% end %>
+    </tbody>
+</table>

--- a/app/views/user/machines/new.html.erb
+++ b/app/views/user/machines/new.html.erb
@@ -1,0 +1,23 @@
+<h1>新規織機追加</h1>
+
+<%= form_with model: @machine, url: user_machines_path, local: true do |f| %>
+    <div>
+        <%= f.label :name, '織機名' %><br>
+        <%= f.text_field :name %>
+    </div>
+
+    <div>
+        <%= f.label :machine_type_id, '織機の種類' %><br>
+        <%= f.collection_select :machine_type_id, MachineType.all, :id, :name %>
+    </div>
+
+    <div class="form-group">
+        <%= f.label :company_id, "会社名:" %><br>
+        <%= f.collection_select :company_id, Company.all, :id, :name, { prompt: "Select Company" }, { class: "form-control" } %>
+    </div>
+
+    <div>
+        <%= f.submit '作成' %>
+        <%= link_to '戻る', user_machines_path, class: "btn btn-secondary" %>
+    </div>
+<% end %>

--- a/app/views/user/machines/show.html.erb
+++ b/app/views/user/machines/show.html.erb
@@ -1,0 +1,62 @@
+<h1>織機詳細</h1>
+
+<p>
+    <strong>織機名:</strong>
+    <%= @machine.name %>
+</p>
+<p>
+    <strong>織機のタイプ:</strong>
+    <%= @machine.machine_type.name %>
+</p>
+<p>
+    <strong>会社名:</strong>
+    <%= @machine.company.name %>
+</p>
+<p>
+    <strong>稼働状況:</strong>
+    <% current_work_process = find_current_work_process(@machine.work_processes) %>
+    <% if current_work_process && current_work_process.machine_assignments.any? %>
+        <% current_work_process.machine_assignments.each do |assignment| %>
+        <%= assignment.machine_status.name %><br>
+        <% end %>
+    <% else %>
+        N/A
+    <% end %>
+</p>
+
+
+<h2>作業工程</h2>
+
+<% if @work_processes.any? %>
+    <table class="table table-bordered">
+        <thead>
+            <tr>
+                <th>品番</th>
+                <th>作業工程</th>
+                <th>ステータス</th>
+                <th>開始日</th>
+                <th>受注状況</th>
+            </tr>
+        </thead>
+
+        <tbody>
+            <% @work_processes.each do |wp| %>
+            <tr>
+                <td><%= wp.order.product_number.number %></td>
+                <td><%= wp.work_process_definition.name %></td>
+                <td><%= wp.work_process_status.name %></td>
+                <td><%= wp.start_date %></td>
+                <td>
+                    <%= link_to '受注を確認する', user_order_path(wp.order), class: 'btn btn-info btn-sm' %>
+                </td>
+            </tr>
+            <% end %>
+        </tbody>
+    </table>
+<% else %>
+    <p>織機情報が見つかりませんでした。</p>
+<% end %>
+
+<%= link_to '織機を編集', edit_user_machine_path(@machine), class: 'btn btn-primary' %>
+<%= link_to '削除', user_machine_path(@machine), data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか？' }, class: "btn btn-danger btn-sm" %>
+<%= link_to '戻る', user_machines_path, class: 'btn btn-secondary' %>

--- a/app/views/user/orders/_form.html.erb
+++ b/app/views/user/orders/_form.html.erb
@@ -1,0 +1,96 @@
+<%= form_with(model: [:user, @order], local: true) do |form| %>
+    <% if @order.errors.any? %>
+        <div class="alert alert-danger">
+        <h4><%= pluralize(@order.errors.count, "error") %> prohibited this order from being saved:</h4>
+        <ul>
+            <% @order.errors.full_messages.each do |message| %>
+            <li><%= message %></li>
+            <% end %>
+        </ul>
+        </div>
+    <% end %>
+
+    <div class="form-group">
+        <%= form.label :company_id, "会社名" %>
+        <%= form.collection_select :company_id, Company.all, :id, :name, { prompt: "選択してください" }, { class: "form-control" } %>
+    </div>
+
+    <div class="form-group">
+        <%= form.label :product_number_id, "品番" %>
+        <%= form.collection_select :product_number_id, ProductNumber.all, :id, :number, { prompt: "選択してください" }, { class: "form-control" } %>
+    </div>
+
+    <div class="form-group">
+        <%= form.label :color_number_id, "色番" %>
+        <%= form.collection_select :color_number_id, ColorNumber.all, :id, :color_code, { prompt: "選択してください" }, { class: "form-control" } %>
+    </div>
+
+    <div class="form-group">
+        <%= form.label :roll_count, "ロール数" %>
+        <%= form.number_field :roll_count, class: "form-control" %>
+    </div>
+
+    <div class="form-group">
+        <%= form.label :quantity, "数量" %>
+        <%= form.number_field :quantity, class: "form-control" %>
+    </div>
+
+    <div class="form-group">
+        <%= form.label :start_date, "開始日" %>
+        <%= form.date_select :start_date, { start_year: 2020, end_year: 2030 }, { class: "form-control" } %>
+    </div>
+
+    <h3>作業工程</h3>
+    <table class="table table-bordered">
+        <thead>
+        <tr>
+            <th>作業工程定義</th>
+            <th>ステータス</th>
+            <th>開始日</th>
+        </tr>
+        </thead>
+        <tbody>
+        <%= form.fields_for :work_processes do |wp_form| %>
+            <tr class="nested-fields">
+                <td>
+                    <%= form.collection_select :work_process_definition_id, WorkProcessDefinition.all, :id, :name, { prompt: "選択してください" }, { class: "form-control" } %>
+                </td>
+                <td>
+                    <%= form.collection_select :work_process_status_id, WorkProcessStatus.all, :id, :name, { prompt: "選択してください" }, { class: "form-control" } %>
+                </td>
+                <td>
+                    <%= form.date_select :start_date, { start_year: 2024, end_year: 2030 }, { class: "form-control" } %>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+
+    <h3>織機の稼働状況</h3>
+    <table class="table table-sm table-bordered">
+        <thead>
+            <tr>
+                <th>織機名</th>
+                <th>稼働状況</th>
+            </tr>
+        </thead>
+        <tbody>
+            <%= form.fields_for :machines do |m_form| %>
+            <tr class="nested-fields">
+                <td>
+                    <%= form.collection_select :machine_id, Machine.all, :id, :name, { prompt: "選択してください" }, { class: "form-control" } %>
+                </td>
+                <td>
+                    <%= form.collection_select :machine_status_id, MachineStatus.all, :id, :name, { prompt: "選択してください" }, { class: "form-control" } %>
+                </td>
+            </tr>
+            <% end %>
+        </tbody>
+    </table>
+    <% end %>
+
+    <% if order.new_record? %>
+        <%= form.submit '作成', class: "btn btn-primary" %>
+    <% else %>
+        <%= form.submit '更新', class: "btn btn-primary" %>
+    <% end %>
+<% end %>

--- a/app/views/user/orders/edit.html.erb
+++ b/app/views/user/orders/edit.html.erb
@@ -1,0 +1,5 @@
+<h1>受注編集</h1>
+
+<%= render 'form', order: @order %>
+
+<%= link_to '戻る', user_order_path(@order), class: "btn btn-primary" %>

--- a/app/views/user/orders/index.html.erb
+++ b/app/views/user/orders/index.html.erb
@@ -1,0 +1,40 @@
+<h1>受注一覧</h1>
+
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th>品番</th>
+            <th>現在の作業工程</th>
+            <th>織機</th>
+        </tr>
+    </thead>
+
+    <tbody>
+        <% @orders.each do |order| %>
+        <% current_wp = find_current_work_process(order.work_processes) %>
+        <tr>
+            <td><%= order.product_number.number %></td>
+            <td>
+                <% if current_wp && current_wp.work_process_definition %>
+                    <%= current_wp.work_process_definition.name %>
+                <% else %>
+                    N/A
+                <% end %>
+            </td>
+            <td>
+                <% if current_wp && current_wp.machines.any? %>
+                    <% current_wp.machines.each do |machine| %>
+                    <%= machine.name %><br>
+                    <% end %>
+                <% else %>
+                    N/A
+                <% end %>
+            </td>
+            <td>
+                <%= link_to '詳細', user_order_path(order), class: "btn btn-info btn-sm" %>
+                <%= link_to '編集', edit_user_order_path(order), class: "btn btn-warning btn-sm" %>
+            </td>
+        </tr>
+        <% end %>
+    </tbody>
+</table>

--- a/app/views/user/orders/new.html.erb
+++ b/app/views/user/orders/new.html.erb
@@ -1,0 +1,5 @@
+<h1>新規受注作成</h1>
+
+<%= render 'form', order: @order %>
+
+<%= link_to '戻る', user_orders_path, class: "btn btn-primary" %>

--- a/app/views/user/orders/show.html.erb
+++ b/app/views/user/orders/show.html.erb
@@ -1,0 +1,85 @@
+<h1>受注詳細</h1>
+
+<p>
+    <strong>会社名:</strong>
+    <%= @order.company.name %>
+</p>
+<p>
+    <strong>品番:</strong>
+    <%= @order.product_number.number %>
+</p>
+<p>
+    <strong>色番:</strong>
+    <%= @order.color_number.color_code %>
+</p>
+<p>
+    <strong>ロール数:</strong>
+    <%= @order.roll_count %>
+</p>
+<p>
+    <strong>数量:</strong>
+    <%= @order.quantity %>
+</p>
+<p>
+    <strong>開始日:</strong>
+    <%= @order.start_date %>
+</p>
+
+<h2>作業工程</h2>
+<table class="table table-bordered">
+    <thead>
+        <tr>
+        <th>作業工程定義</th>
+        <th>織機</th>
+        <th>開始日</th>
+        <th>ステータス</th>
+        </tr>
+    </thead>
+    <tbody>
+        <% @work_processes.each do |wp| %>
+        <tr>
+            <td><%= wp.work_process_definition.name %></td>
+            <td>
+            <% wp.machines.each do |machine| %>
+                <%= machine.name %><br>
+            <% end %>
+            </td>
+            <td><%= wp.start_date %></td>
+            <td><%= wp.work_process_status.name %></td>
+        </tr>
+        <% end %>
+    </tbody>
+</table>
+
+<h2>織機詳細</h2>
+<% if @machines.any? %>
+    <% @machines.each do |machine| %>
+        <p>
+            <strong>織機名:</strong>
+            <%= machine.name %>
+        </p>
+        <p>
+            <strong>織機のタイプ:</strong>
+            <%= machine.machine_type.name %>
+        </p>
+        <p>
+            <strong>会社名:</strong>
+            <%= machine.company.name %>
+        </p>
+        <p>
+            <strong>稼働状況:</strong>
+            <% if @current_machine_assignments.any? %>
+                <% @current_machine_assignments.each do |assignment| %>
+                    <%= assignment.machine_status.name %>
+                <% end %>
+            <% else %>
+                N/A
+            <% end %>
+        </p>
+    <% end %>
+<% else %>
+    <p>織機情報が見つかりませんでした。</p>
+<% end %>
+
+<%= link_to '編集', edit_user_order_path(@order), class: "btn btn-warning" %> |
+<%= link_to '戻る', user_orders_path, class: "btn btn-primary" %>

--- a/app/views/user/users/edit.html.erb
+++ b/app/views/user/users/edit.html.erb
@@ -1,0 +1,27 @@
+<h1>ユーザー情報編集</h1>
+
+<%= form_with model: @user, url: user_user_path(@user), local: true do |f| %>
+    <div>
+        <%= f.label :name, 'ユーザー名' %><br>
+        <%= f.text_field :name %>
+    </div>
+
+    <div>
+        <%= f.label :email, 'メールアドレス' %><br>
+        <%= f.email_field :email %>
+    </div>
+
+    <div>
+        <%= f.label :phone_number, '電話番号' %><br>
+        <%= f.text_field :phone_number %>
+    </div>
+
+    <div>
+        <%= f.label :phone_number, '電話番号' %><br>
+        <%= f.text_field :phone_number %>
+    </div>
+
+    <div>
+        <%= f.submit '更新' %>
+    </div>
+<% end %>

--- a/app/views/user/users/show.html.erb
+++ b/app/views/user/users/show.html.erb
@@ -1,0 +1,21 @@
+<h1>ユーザー情報</h1>
+
+<p>
+    <strong>名前:</strong>
+    <%= @user.name %>
+</p>
+<p>
+    <strong>メール:</strong>
+    <%= @user.email %>
+</p>
+<p>
+    <strong>電話番号:</strong>
+    <%= @user.phone_number %>
+</p>
+<p>
+    <strong>会社名:</strong>
+    <%= @user.company.name %>
+</p>
+
+<%= link_to '編集', edit_user_user_path(@user) %> |
+<%= link_to '戻る', user_root_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,14 +1,26 @@
 Rails.application.routes.draw do
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
+  # Deviseのルーティング（後ステップで設定）
+  # devise_for :users, controllers: {
+  #   sessions: 'users/sessions',
+  #   registrations: 'devise/registrations'
+  # }
 
-  # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
-  # Can be used by load balancers and uptime monitors to verify that the app is live.
-  get "up" => "rails/health#show", as: :rails_health_check
+  # 管理者用の名前空間
+  namespace :admin do
+    root to: 'home#index' # 管理者のホームページ
+    resources :tasks
+    resources :machines
+    resources :orders
+    resources :users
+    resources :products
+  end
 
-  # Render dynamic PWA files from app/views/pwa/*
-  get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
-  get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
-
-  # Defines the root path route ("/")
-  # root "posts#index"
+  # 通常ユーザー用の名前空間
+  namespace :user do
+    get 'home/index'
+    root to: 'home#index'
+    resources :users, only: [:show, :edit, :update]
+    resources :machines, only: [:index, :show, :new, :create, :edit, :update, :destroy]
+    resources :orders, only: [:index, :show, :new, :create, :edit, :update, :destroy]
+  end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,9 +1,268 @@
-# This file should ensure the existence of records required to run the application in every environment (production,
-# development, test). The code here should be idempotent so that it can be executed at any point in every environment.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Example:
-#
-#   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
-#     MovieGenre.find_or_create_by!(name: genre_name)
-#   end
+ActiveRecord::Base.transaction do
+  # 企業データを作成
+  Company.find_or_create_by!(id: 1) { |c| c.name = 'エルトップ' }
+  Company.find_or_create_by!(id: 2) { |c| c.name = '機屋A' }
+  Company.find_or_create_by!(id: 3) { |c| c.name = '機屋B' }
+
+  # ユーザーデータを作成
+  User.find_or_create_by!(id: 1) do |u|
+    u.name = '山田太郎'
+    u.email = 'aaa@example.com'
+    u.phone_number = '000-0000-0000'
+    u.company_id = 1
+    u.admin = true
+  end
+
+  User.find_or_create_by!(id: 2) do |u|
+    u.name = '佐藤花子'
+    u.email = 'bbb@example.com'
+    u.phone_number = '000-0000-0001'
+    u.company_id = 2
+    u.admin = false
+  end
+
+  # 品番データを作成
+  ProductNumber.find_or_create_by!(id: 1) { |pn| pn.number = 'PN-10' }
+  ProductNumber.find_or_create_by!(id: 2) { |pn| pn.number = 'PN-20' }
+  ProductNumber.find_or_create_by!(id: 3) { |pn| pn.number = 'PN-30' }
+
+  # 色番データを作成
+  ColorNumber.find_or_create_by!(id: 1) { |cn| cn.color_code = 'C-001' }
+  ColorNumber.find_or_create_by!(id: 2) { |cn| cn.color_code = 'C-002' }
+  ColorNumber.find_or_create_by!(id: 3) { |cn| cn.color_code = 'C-003' }
+  ColorNumber.find_or_create_by!(id: 4) { |cn| cn.color_code = 'C-004' }
+
+  # 発注データを作成
+  Order.find_or_create_by!(id: 1) do |o|
+    o.company_id = 1
+    o.product_number_id = 1
+    o.color_number_id = 1
+    o.roll_count = 100
+    o.quantity = 1000
+    o.start_date = '2023-10-01'
+  end
+
+  Order.find_or_create_by!(id: 2) do |o|
+    o.company_id = 2
+    o.product_number_id = 3
+    o.color_number_id = 3
+    o.roll_count = 50
+    o.quantity = 500
+    o.start_date = '2023-10-05'
+  end
+
+  # 織機の種類データを作成
+  MachineType.find_or_create_by!(id: 1) { |mt| mt.name = 'ドビー' }
+  MachineType.find_or_create_by!(id: 2) { |mt| mt.name = 'ジャガード' }
+
+  # 織機データを作成
+  Machine.find_or_create_by!(id: 1) do |m|
+    m.name = '1号機'
+    m.machine_type_id = 1
+    m.company_id = 2
+  end
+
+  Machine.find_or_create_by!(id: 2) do |m|
+    m.name = '2号機'
+    m.machine_type_id = 1
+    m.company_id = 2
+  end
+
+  Machine.find_or_create_by!(id: 3) do |m|
+    m.name = '3号機'
+    m.machine_type_id = 2
+    m.company_id = 2
+  end
+
+  # 織機の稼働状況データを作成
+  MachineStatus.find_or_create_by!(id: 1) { |ms| ms.name = '未稼働' }
+  MachineStatus.find_or_create_by!(id: 2) { |ms| ms.name = '準備中' }
+  MachineStatus.find_or_create_by!(id: 3) { |ms| ms.name = '稼働中' }
+  MachineStatus.find_or_create_by!(id: 4) { |ms| ms.name = '故障中' }
+
+  # 作業工程定義データを作成
+  WorkProcessDefinition.find_or_create_by!(id: 1) { |wpd| wpd.name = '糸'; wpd.sequence = 1 }
+  WorkProcessDefinition.find_or_create_by!(id: 2) { |wpd| wpd.name = '染色'; wpd.sequence = 2 }
+  WorkProcessDefinition.find_or_create_by!(id: 3) { |wpd| wpd.name = '整経'; wpd.sequence = 3 }
+  WorkProcessDefinition.find_or_create_by!(id: 4) { |wpd| wpd.name = '製織'; wpd.sequence = 4 }
+  WorkProcessDefinition.find_or_create_by!(id: 5) { |wpd| wpd.name = '整理加工'; wpd.sequence = 5 }
+
+  # 作業工程ステータスデータを作成
+  WorkProcessStatus.find_or_create_by!(id: 1) { |wps| wps.name = '作業前' }
+  WorkProcessStatus.find_or_create_by!(id: 2) { |wps| wps.name = '作業中' }
+  WorkProcessStatus.find_or_create_by!(id: 3) { |wps| wps.name = '作業完了' }
+  WorkProcessStatus.find_or_create_by!(id: 4) { |wps| wps.name = '確認中' }
+
+  # ナレッジデータを作成
+  ProcessEstimate.find_or_create_by!(id: 1) do |pe|
+    pe.work_process_definition_id = 1
+    pe.machine_type_id = 1
+    pe.earliest_completion_estimate = 90
+    pe.latest_completion_estimate = 150
+    pe.update_date = '2024-12-01'
+  end
+
+  ProcessEstimate.find_or_create_by!(id: 2) do |pe|
+    pe.work_process_definition_id = 2
+    pe.machine_type_id = 1
+    pe.earliest_completion_estimate = 14
+    pe.latest_completion_estimate = 21
+    pe.update_date = '2024-12-01'
+  end
+
+  ProcessEstimate.find_or_create_by!(id: 3) do |pe|
+    pe.work_process_definition_id = 3
+    pe.machine_type_id = 1
+    pe.earliest_completion_estimate = 7
+    pe.latest_completion_estimate = 14
+    pe.update_date = '2024-12-01'
+  end
+
+  ProcessEstimate.find_or_create_by!(id: 4) do |pe|
+    pe.work_process_definition_id = 4
+    pe.machine_type_id = 1
+    pe.earliest_completion_estimate = 25
+    pe.latest_completion_estimate = 30
+    pe.update_date = '2024-12-01'
+  end
+
+  ProcessEstimate.find_or_create_by!(id: 5) do |pe|
+    pe.work_process_definition_id = 5
+    pe.machine_type_id = 1
+    pe.earliest_completion_estimate = 4
+    pe.latest_completion_estimate = 5
+    pe.update_date = '2024-12-01'
+  end
+
+  ProcessEstimate.find_or_create_by!(id: 6) do |pe|
+    pe.work_process_definition_id = 1
+    pe.machine_type_id = 2
+    pe.earliest_completion_estimate = 30
+    pe.latest_completion_estimate = 40
+    pe.update_date = '2024-12-01'
+  end
+
+  ProcessEstimate.find_or_create_by!(id: 7) do |pe|
+    pe.work_process_definition_id = 2
+    pe.machine_type_id = 2
+    pe.earliest_completion_estimate = 21
+    pe.latest_completion_estimate = 28
+    pe.update_date = '2024-12-01'
+  end
+
+  ProcessEstimate.find_or_create_by!(id: 8) do |pe|
+    pe.work_process_definition_id = 3
+    pe.machine_type_id = 2
+    pe.earliest_completion_estimate = 14
+    pe.latest_completion_estimate = 21
+    pe.update_date = '2024-12-01'
+  end
+
+  ProcessEstimate.find_or_create_by!(id: 9) do |pe|
+    pe.work_process_definition_id = 4
+    pe.machine_type_id = 2
+    pe.earliest_completion_estimate = 30
+    pe.latest_completion_estimate = 40
+    pe.update_date = '2024-12-01'
+  end
+
+  ProcessEstimate.find_or_create_by!(id: 10) do |pe|
+    pe.work_process_definition_id = 5
+    pe.machine_type_id = 2
+    pe.earliest_completion_estimate = 4
+    pe.latest_completion_estimate = 5
+    pe.update_date = '2024-12-01'
+  end
+
+  # 作業工程データを作成
+  WorkProcess.find_or_create_by!(id: 1) do |wp|
+    wp.order_id = 1
+    wp.process_estimate_id = 1
+    wp.work_process_definition_id = 1
+    wp.work_process_status_id = 3
+    wp.start_date = '2023-10-01'
+    wp.earliest_estimated_completion_date = '2023-12-30'
+    wp.latest_estimated_completion_date = '2023-12-30'
+    wp.factory_estimated_completion_date = '2023-10-05'
+    wp.actual_completion_date = '2023-10-03'
+  end
+
+  WorkProcess.find_or_create_by!(id: 2) do |wp|
+    wp.order_id = 1
+    wp.process_estimate_id = 2
+    wp.work_process_definition_id = 2
+    wp.work_process_status_id = 2
+    wp.start_date = '2023-10-03'
+    wp.earliest_estimated_completion_date = '2023-10-17'
+    wp.latest_estimated_completion_date = '2023-10-17'
+    wp.factory_estimated_completion_date = '2023-10-10'
+    wp.actual_completion_date = '2023-10-10'
+  end
+
+  WorkProcess.find_or_create_by!(id: 3) do |wp|
+    wp.order_id = 1
+    wp.process_estimate_id = 3
+    wp.work_process_definition_id = 3
+    wp.work_process_status_id = 1
+    wp.start_date = '2023-10-05'
+    wp.earliest_estimated_completion_date = '2023-10-27'
+    wp.latest_estimated_completion_date = '2023-10-27'
+    wp.factory_estimated_completion_date = '2023-10-20'
+    wp.actual_completion_date = '2023-10-10'
+  end
+
+  WorkProcess.find_or_create_by!(id: 4) do |wp|
+    wp.order_id = 1
+    wp.process_estimate_id = 4
+    wp.work_process_definition_id = 4
+    wp.work_process_status_id = 4
+    wp.start_date = '2023-10-15'
+    wp.earliest_estimated_completion_date = '2023-11-26'
+    wp.latest_estimated_completion_date = '2023-11-26'
+    wp.factory_estimated_completion_date = '2023-11-01'
+    wp.actual_completion_date = '2023-10-10'
+  end
+
+  WorkProcess.find_or_create_by!(id: 5) do |wp|
+    wp.order_id = 1
+    wp.process_estimate_id = 5
+    wp.work_process_definition_id = 5
+    wp.work_process_status_id = 1
+    wp.start_date = '2023-10-20'
+    wp.earliest_estimated_completion_date = '2023-12-02'
+    wp.latest_estimated_completion_date = '2023-12-02'
+    wp.factory_estimated_completion_date = '2023-11-28'
+    wp.actual_completion_date = '2023-10-10'
+  end
+
+  # 織機割り当てデータを作成（全作業工程を1つの織機に割り当て）
+  MachineAssignment.find_or_create_by!(id: 1) do |ma|
+    ma.work_process_id = 1
+    ma.machine_id = 1
+    ma.machine_status_id = 1 # 未稼働
+  end
+
+  MachineAssignment.find_or_create_by!(id: 2) do |ma|
+    ma.work_process_id = 2
+    ma.machine_id = 1
+    ma.machine_status_id = 2 # 準備中
+  end
+
+  MachineAssignment.find_or_create_by!(id: 3) do |ma|
+    ma.work_process_id = 3
+    ma.machine_id = 1
+    ma.machine_status_id = 3 # 稼働中
+  end
+
+  MachineAssignment.find_or_create_by!(id: 4) do |ma|
+    ma.work_process_id = 4
+    ma.machine_id = 1
+    ma.machine_status_id = 4 # 確認中（WorkProcessDefinition id:4に対応）
+  end
+
+  MachineAssignment.find_or_create_by!(id: 5) do |ma|
+    ma.work_process_id = 5
+    ma.machine_id = 1
+    ma.machine_status_id = 1 # 未稼働
+  end
+end

--- a/test/controllers/user/home_controller_test.rb
+++ b/test/controllers/user/home_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class User::HomeControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get user_home_index_url
+    assert_response :success
+  end
+end

--- a/test/controllers/user/machines_controller_test.rb
+++ b/test/controllers/user/machines_controller_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class User::MachinesControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get user_machines_index_url
+    assert_response :success
+  end
+
+  test "should get show" do
+    get user_machines_show_url
+    assert_response :success
+  end
+end

--- a/test/controllers/user/orders_controller_test.rb
+++ b/test/controllers/user/orders_controller_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+class User::OrdersControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get user_orders_index_url
+    assert_response :success
+  end
+
+  test "should get show" do
+    get user_orders_show_url
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get user_orders_edit_url
+    assert_response :success
+  end
+
+  test "should get update" do
+    get user_orders_update_url
+    assert_response :success
+  end
+end

--- a/test/controllers/user/users_controller_test.rb
+++ b/test/controllers/user/users_controller_test.rb
@@ -1,0 +1,18 @@
+require "test_helper"
+
+class User::UsersControllerTest < ActionDispatch::IntegrationTest
+  test "should get show" do
+    get user_users_show_url
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get user_users_edit_url
+    assert_response :success
+  end
+
+  test "should get update" do
+    get user_users_update_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
- 今回対応した内容は以下の通り
  - 機屋で使用予定のページを作成
    1. Home画面
    2. ユーザー情報画面
    3. 織機一覧画面
    4. 受注一覧画面
  - a ~ d のページにおけるCRUD機能の実装
    - 編集機能は対応が不十分な箇所が多い
    - 受注一覧は機屋側で誤って受注を取り消さないよう削除ボタンを配置していません
    - N/A は該当するデータがない場合の表示になります


- 今回未対応、もしくは対応不十分と思われる箇所は以下を想定
  - Home画面全般
  - 編集機能
  - 各ボタンの遷移先
  - 管理者（問屋）とユーザー（機屋）との連携
  - ある特定の機屋に関するデータを表示させる機能

- issueのURL
https://github.com/yuutyan2008/loom_management/issues/7