### PR TITLE
発注管理画面の編集機能

### DIFF
--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -6,6 +6,16 @@ before_action :admin_user
 
   def index
     @orders = Order.includes(work_processes: [:work_process_definition, :work_process_status, :process_estimate])
+
+    # 各注文に対して現在作業中の作業工程を取得
+    @current_work_processes = {}
+    @orders.each do |order|
+      if order.work_processes.any?
+        @current_work_processes[order.id] = order.work_processes.current_work_process
+      else
+        @current_work_processes[order.id] = nil
+      end
+    end
   end
 
   def new
@@ -89,7 +99,7 @@ before_action :admin_user
       end
 
     end
-    binding.irb
+    # binding.irb/
     redirect_to admin_order_path(@order), notice: "作業工程が更新されました。"
   end
 

--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -1,5 +1,7 @@
 class Admin::OrdersController < ApplicationController
-before_action :order_params, only: %i[create update]
+before_action :order_params, only: [:create,  :update]
+before_action :work_processes_params, only: [:update_work_processes]
+before_action :set_order, only: [:edit, :show, :update, :destroy, :edit_work_processes, :update_work_processes]
 before_action :admin_user
 
   def index
@@ -34,20 +36,17 @@ before_action :admin_user
   end
 
   def show
-    @order = Order.find(params[:id])
+    @order
   end
+
   def edit
-    @order = Order.find_by(id: params[:id])
     if @order.nil?
       Rails.logger.debug "注文が見つかりません"
-      # もしくは以下のコードで例外を投げる
       raise "注文が見つかりません"
     end
   end
 
   def update
-    @order = Order.find(params[:id])
-
     if @order.update(order_params)
       # 国際化（i18n）
       # ja.yml に定義したフラッシュメッセージに翻訳
@@ -55,17 +54,47 @@ before_action :admin_user
       flash[:notice] = "発注が更新されました"
 
 
-      redirect_to admin_orders_path
+      redirect_to admin_order_path(@order)
     else
       flash.now[:alert] = @order.errors.full_messages.join(", ") # エラーメッセージを追加
       render :edit
     end
   end
 
+  # 作業工程の編集
+  def edit_work_processes
+    # 必要なデータを渡す
+    @work_processes = @order.work_processes
+  end
+
+  # 作業工程の更新
+  def update_work_processes
+    # strongparameterで許可されたフォームのname属性値を取得
+    permitted_params = work_processes_params.to_h
+    # フォームデータからIDを取得
+    work_process_ids = permitted_params.keys
+    # IDを指定してDBからデータ取得
+    @work_processes = WorkProcess.where(id: work_process_ids)
+
+    # success = true # フラグ初期化
+    @work_processes.each do |work_process|
+      # フォームデータからこのレコードに対応するパラメータを取得、idを文字列に変換
+      update_record = permitted_params[work_process.id.to_s]
+
+      # 更新処理を実行
+      unless work_process.update(update_record)
+
+        flash.now[:alert] = "作業工程の更新に失敗しました。"
+        render :edit_work_processes and return
+      end
+
+    end
+    binding.irb
+    redirect_to admin_order_path(@order), notice: "作業工程が更新されました。"
+  end
+
   # 削除処理の開始し管理者削除を防ぐロジックはmodelで行う
   def destroy
-    # binding.irb
-    @order = Order.find(params[:id])
     if @order.destroy
       # ココ(削除実行直前)でmodelに定義したコールバックが呼ばれる
 
@@ -80,7 +109,6 @@ before_action :admin_user
 
   private
   # フォームの入力値のみ許可
-
   def order_params
     params.require(:order).permit(
       :company_id,
@@ -90,8 +118,32 @@ before_action :admin_user
       :quantity,
       # :start_date, # 重複のためorderテーブルのstart_dateを削除
       :factory_estimated_completion_date,
+      :earliest_estimated_completion_date,
+      :latest_estimated_completion_date,
+      :actual_completion_date,
       :start_date,
     )
+  end
+
+  def work_processes_params
+    permitted = {}
+    params[:work_processes].keys.each do |key|
+      permitted[key] = [
+        :id,
+        :work_process_status_id,
+        :start_date,
+        :earliest_estimated_completion_date,
+        :latest_estimated_completion_date,
+        :factory_estimated_completion_date,
+        :actual_completion_date
+      ]
+    end
+    params.require(:work_processes).permit(permitted)
+  end
+
+
+  def set_order
+    @order = Order.find(params[:id])
   end
 
   # 一般ユーザがアクセスした場合には一覧画面にリダイレクト

--- a/app/models/work_process.rb
+++ b/app/models/work_process.rb
@@ -37,4 +37,21 @@ class WorkProcess < ApplicationRecord
       },
     ]
   end
+
+  # 現在作業中の作業工程を取得するスコープ
+  def self.current_work_process
+    # 最新の「作業完了」ステータスの作業工程を取得
+    latest_completed_wp = joins(:work_process_status)
+                            .where(work_process_statuses: { name: '作業完了' })
+                            .order(start_date: :desc)
+                            .first
+
+    if latest_completed_wp
+      # 最新の「作業完了」より後の作業工程を取得
+      where('start_date > ?', latest_completed_wp.start_date).order(:start_date).first
+    else
+      # 「作業完了」がない場合、最も古い作業工程を取得
+      order(:start_date).first
+    end
+  end
 end

--- a/app/views/admin/orders/edit.html.erb
+++ b/app/views/admin/orders/edit.html.erb
@@ -1,5 +1,4 @@
-<%# 発注済み商品の編集 %>
-<h1><%= t('view.users.admin.edit.title') %></h1>
+<h1>発注済み商品の編集</h1>
 
 <%# フォームが表示される前にエラーメッセージを表示するためform_withの前に書く %>
 <% if @order.errors.any? %>
@@ -25,7 +24,6 @@
     </tr>
   </thead>
   <tbody>
-    <!-- 企業名 -->
     <tr>
       <td>企業名</td>
       <td><%= @order.company&.name || "企業情報なし" %></td>
@@ -38,7 +36,6 @@
       </td>
     </tr>
 
-    <!-- 商品番号 -->
     <tr>
       <td>商品番号</td>
       <td><%= @order.product_number&.number || "番号なし" %></td>
@@ -51,7 +48,6 @@
       </td>
     </tr>
 
-    <!-- 色番号 -->
     <tr>
       <td>色番号</td>
       <td><%= @order.color_number&.color_code || "色番号なし" %></td>
@@ -64,7 +60,6 @@
       </td>
     </tr>
 
-    <!-- ロール数 -->
     <tr>
       <td>ロール数</td>
       <td><%= @order.roll_count || "未設定" %></td>
@@ -73,7 +68,6 @@
       </td>
     </tr>
 
-    <!-- 数量 -->
     <tr>
       <td>数量</td>
       <td><%= @order.quantity || "未設定" %></td>
@@ -82,7 +76,6 @@
       </td>
     </tr>
 
-    <!-- 開始日 -->
     <tr>
       <td>開始日</td>
       <td><%= @order.start_date&.strftime("%Y-%m-%d") || "日付なし" %></td>

--- a/app/views/admin/orders/edit_work_processes.html.erb
+++ b/app/views/admin/orders/edit_work_processes.html.erb
@@ -5,6 +5,7 @@
     <thead>
         <tr>
             <th>現在の工程</th>
+            <th>機械の稼働状況</th>
             <th>現在の工程のステータス</th>
             <th>作業開始日</th>
             <th>完了見込み(最短)</th>
@@ -15,14 +16,24 @@
     </thead>
     <tbody>
         <% @work_processes.each do |process| %>
+        <% process.machine_assignments.each do |assignment| %>
         <tr>
             <td><%= process&.work_process_definition&.name || "N/A" %></td>
 
-            <td><%= f.collection_select :name,
-          WorkProcessStatus.all, :id, :name,
-          selected: process&.work_process_status_id,
+            <td>
+                <%= f.collection_select "work_processes[#{process.id}][machine_assignments][#{assignment.id}][machine_status_id]",
+          MachineStatus.all, :id, :name,
+          selected: assignment.machine_status_id,
           include_blank: "選択してください" %>
             </td>
+
+            <td>
+                <%= f.collection_select "work_processes[#{process.id}][work_process_status_id]",
+          WorkProcessStatus.all, :id, :name,
+          selected: process.work_process_status_id,
+          include_blank: "選択してください" %>
+            </td>
+
 
             <td><%= f.date_field "work_processes[#{process.id}][start_date]",
         value: process&.start_date,
@@ -53,6 +64,7 @@
         placeholder: "機屋の完了日を選択してください" %>
             </td>
         </tr>
+        <% end %>
         <% end %>
     </tbody>
 </table>

--- a/app/views/admin/orders/edit_work_processes.html.erb
+++ b/app/views/admin/orders/edit_work_processes.html.erb
@@ -1,0 +1,64 @@
+<h1>作業工程の編集</h1>
+
+<%= form_with url: update_work_processes_admin_order_path(@order), method: :patch, local: true do |f| %>
+<table border="1" cellpadding="5" cellspacing="0">
+    <thead>
+        <tr>
+            <th>現在の工程</th>
+            <th>現在の工程のステータス</th>
+            <th>作業開始日</th>
+            <th>完了見込み(最短)</th>
+            <th>完了見込み(最長)</th>
+            <th>機屋の完了予定日</th>
+            <th>機屋の完了日</th>
+        </tr>
+    </thead>
+    <tbody>
+        <% @work_processes.each do |process| %>
+        <tr>
+            <td><%= process&.work_process_definition&.name || "N/A" %></td>
+
+            <td><%= f.collection_select :name,
+          WorkProcessStatus.all, :id, :name,
+          selected: process&.work_process_status_id,
+          include_blank: "選択してください" %>
+            </td>
+
+            <td><%= f.date_field "work_processes[#{process.id}][start_date]",
+        value: process&.start_date,
+        placeholder: "作業開始日を選択してください" %>
+            </td>
+
+            <td>
+                <%= f.date_field "work_processes[#{process.id}][earliest_estimated_completion_date]",
+        value: process&.earliest_estimated_completion_date,
+        placeholder: "完了見込み(最短)を選択してください" %>
+            </td>
+
+            <td>
+                <%= f.date_field "work_processes[#{process.id}][latest_estimated_completion_date]",
+        value: process&.latest_estimated_completion_date,
+        placeholder: "完了見込み(最長)を選択してください" %>
+            </td>
+
+            <td>
+                <%= f.date_field "work_processes[#{process.id}][factory_estimated_completion_date]",
+        value: process&.factory_estimated_completion_date,
+        placeholder: "機屋の完了予定日を選択してください" %>
+            </td>
+
+            <td>
+                <%= f.date_field "work_processes[#{process.id}][actual_completion_date]",
+        value: process&.actual_completion_date,
+        placeholder: "機屋の完了日を選択してください" %>
+            </td>
+        </tr>
+        <% end %>
+    </tbody>
+</table>
+
+<div>
+    <%= f.submit "更新", class: "btn btn-primary" %>
+    <%= link_to "キャンセルして戻る", admin_order_path(@order), class: "btn btn-secondary" %>
+</div>
+<% end %>

--- a/app/views/admin/orders/index.html.erb
+++ b/app/views/admin/orders/index.html.erb
@@ -13,16 +13,17 @@
   </thead>
   <tbody>
     <% @orders.each do |order| %>
+    <% current_process = @current_work_processes[order.id] %>
+    <% if current_process %>
     <tr>
       <td><%= order.company.name %></td>
       <td><%= order.product_number.number %></td>
       <td><%= order.color_number.color_code %></td>
       <td>
-        <%# order.work_processesが複数存在するため全てを表示する %>
-        <%= order.work_processes.order(updated_at: :desc).first&.work_process_definition&.name.presence || "未設定" %>
+        <%= current_process.work_process_definition&.name.presence || "未設定" %>
       </td>
-      <td><%= order.work_processes.order(updated_at: :desc).first&.start_date %></td>
-      <td><%= order.work_processes.order(updated_at: :desc).first&.factory_estimated_completion_date %></td>
+      <td><%= current_process.start_date %></td>
+      <td><%= current_process.factory_estimated_completion_date %></td>
 
 
 
@@ -33,6 +34,7 @@
         data: {turbo_method: :delete, turbo_confirm: "本当に削除してよろしいですか？"} %>
       </td>
     </tr>
+    <% end %>
     <% end %>
   </tbody>
 </table>

--- a/app/views/admin/orders/index.html.erb
+++ b/app/views/admin/orders/index.html.erb
@@ -7,7 +7,7 @@
       <th>品番</th>
       <th>色番</th>
       <th>現在の工程</th>
-      <th>発注日</th>
+      <th>開始日</th>
       <th>機屋の予定納期</th>
     </tr>
   </thead>
@@ -23,6 +23,7 @@
       </td>
       <td><%= order.work_processes.order(updated_at: :desc).first&.start_date %></td>
       <td><%= order.work_processes.order(updated_at: :desc).first&.factory_estimated_completion_date %></td>
+
 
 
       <td>

--- a/app/views/admin/orders/new.html.erb
+++ b/app/views/admin/orders/new.html.erb
@@ -69,13 +69,6 @@
         <%= f.date_field :start_date, placeholder: "発注日を選択してください" %>
       </td>
     </tr>
-
-    <tr>
-      <td>機屋の予定納期</td>
-      <td>
-        <%= f.date_field :factory_estimated_completion_date, placeholder: "機屋の予定納期を選択してください" %>
-      </td>
-    </tr>
   </tbody>
 </table>
 

--- a/app/views/admin/orders/show.html.erb
+++ b/app/views/admin/orders/show.html.erb
@@ -9,6 +9,7 @@
       <th>反数</th>
       <th>数量</th>
       <th>現在の工程</th>
+      <th>機械の稼働状況</th>
       <th>現在の工程の状況</th>
       <th>開始日</th>
       <th>完了見込み(最短)</th>
@@ -20,6 +21,7 @@
   <tbody>
     <%# 各工程を行単位で表示する %>
     <% @order.work_processes.each do |process| %>
+    <% process.machine_assignments.each do |assignment| %>
     <tr>
       <td><%= @order.company.name %></td>
       <td><%= @order.product_number.number %></td>
@@ -27,6 +29,7 @@
       <td><%= @order.roll_count %></td>
       <td><%= @order.quantity %></td>
       <td><%= process&.work_process_definition&.name || "N/A" %></td>
+      <td><%= assignment&.machine_status.name || "N/A" %></td>
       <td><%= process&.work_process_status&.name || "N/A" %></td>
       <td><%= process&.start_date || "N/A" %></td>
       <td><%= process&.earliest_estimated_completion_date || "N/A" %></td>
@@ -39,6 +42,7 @@
         <%= link_to '削除', admin_order_path(@order), method: :delete, data: {turbo_method: :delete, turbo_confirm: "本当に削除してよろしいですか？" } %>
       </td>
     </tr>
+    <% end %>
     <% end %>
   </tbody>
 </table>

--- a/app/views/admin/orders/show.html.erb
+++ b/app/views/admin/orders/show.html.erb
@@ -10,11 +10,11 @@
       <th>数量</th>
       <th>現在の工程</th>
       <th>現在の工程の状況</th>
-      <th>作業開始日</th>
-      <th>最短作業日数</th>
-      <th>最長作業日数</th>
-      <th>最短予定納期</th>
-      <th>最長予定納期</th>
+      <th>開始日</th>
+      <th>完了見込み(最短)</th>
+      <th>完了見込み(最長)</th>
+      <th>機屋の完了予定日</th>
+      <th>機屋の完了日</th>
     </tr>
   </thead>
   <tbody>
@@ -34,7 +34,8 @@
       <td><%= process&.factory_estimated_completion_date || "N/A" %></td>
       <td><%= process&.actual_completion_date || "N/A" %></td>
       <td>
-        <%= link_to '編集', edit_admin_order_path(@order), class: "edit-order" %> |
+        <%= link_to '発注の編集', edit_admin_order_path(@order), class: "edit-order" %> |
+        <%= link_to '作業工程の編集', edit_work_processes_admin_order_path(@order), class: "edit_work_processes_admin_order" %>|
         <%= link_to '削除', admin_order_path(@order), method: :delete, data: {turbo_method: :delete, turbo_confirm: "本当に削除してよろしいですか？" } %>
       </td>
     </tr>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,12 @@ Rails.application.routes.draw do
   namespace :admin do
     root to: 'home#index'
     resources :machines
-    resources :orders
+    resources :orders do
+      member do
+        get 'edit_work_processes'
+        patch 'update_work_processes'
+      end
+    end
     resources :users
     resources :products
   end


### PR DESCRIPTION
発注管理画面からの作業工程、機械の稼働状況の編集機能を実装しました。
ご確認よろしくお願いします。

まだできていない点：作業工程名の並び替え固定

関連するissueは以下になります
https://github.com/yuutyan2008/loom_management/issues/13
https://github.com/yuutyan2008/loom_management/issues/15

