### PR TITLE
機屋の更新処理、新規発注について

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -71,67 +71,14 @@ class OrdersController < ApplicationController
 
   def update
     ActiveRecord::Base.transaction do
-      # 追記：作業完了日入力時の更新
-      order_work_processes = update_order_params.except(:machine_assignments_attributes)
-
-      # 完了日の取得
-      workprocesses = order_work_processes[:work_processes_attributes].values
-
-      next_start_date = nil
-      workprocesses.each_with_index do |workprocess, index|
-        work_process_record = WorkProcess.find(workprocess["id"])
-
-        if index == 0
-          start_date = workprocess["start_date"]
-        else
-          start_date = next_start_date
-        end
-
-        # 見込み完了日、作業開始日更新
-        actual_completion_date = workprocess["actual_completion_date"]
-
-        # 開始日、見込み完了日置き換え
-        updated_date, next_start_date = WorkProcess.check_current_work_process(workprocess, start_date, actual_completion_date)
-
-        # 更新された値を反映
-        work_process_record.update!(updated_date)
-      end
-      # MachineAssignmentの更新
-      machine_assignments_params = update_order_params[:machine_assignments_attributes]
-      machine_id = machine_assignments_params[0][:machine_id].to_i
-      machine_status_id = machine_assignments_params[0][:machine_status_id].to_i
-      # フォームで送られた ID に基づき MachineAssignment を取得
-      machine_ids = @order.work_processes.joins(:machine_assignments).pluck('machine_assignments.machine_id').uniq
-      if machine_ids.any?
-        @order.machine_assignments.each do |assignment|
-          assignment.update!(
-            machine_id: machine_id,
-            machine_status_id: machine_status_id
-          )
-        end
-      else
-        # 存在しない場合は新規作成し、@order に関連付ける
-        @order.work_processes.each do |work_process|
-          work_process.machine_assignments.create!(
-            machine_id: machine_id,
-            machine_status_id: machine_status_id
-          )
-        end
-      end
-      # binding.irb
-
-      # Orderの更新
-      update_order = update_order_params.except(:machine_assignments_attributes, :work_processes_attributes)
-      if update_order.present?
-        @order.update!(update_order)
-      end
+      update_work_processes
+      update_machine_assignments if machine_assignments_present?
+      update_order_details
     end
     redirect_to order_path(@order), notice: "更新されました。"
-
   rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotSaved => e
-    # トランザクション内でエラーが発生した場合はロールバックされる
     flash[:alert] = "更新に失敗しました: #{e.message}"
-    redirect_to admin_order_path(@order)
+    redirect_to edit_order_path(@order)
   end
 
   def destroy
@@ -251,6 +198,73 @@ class OrdersController < ApplicationController
         work_process_id: work_process_id
       )
     end
+  end
+
+  # WorkProcess の更新を担当
+  def update_work_processes
+    order_work_processes = update_order_params.except(:machine_assignments_attributes)
+    work_processes = order_work_processes[:work_processes_attributes].values
+
+    next_start_date = nil
+    work_processes.each_with_index do |work_process, index|
+      work_process_record = WorkProcess.find(work_process["id"])
+
+      if index == 0
+        start_date = work_process["start_date"]
+      else
+        start_date = next_start_date
+      end
+
+      actual_completion_date = work_process["actual_completion_date"]
+
+      updated_date, next_start_date = WorkProcess.check_current_work_process(work_process, start_date, actual_completion_date)
+      work_process_record.update!(updated_date)
+    end
+  end
+
+  # MachineAssignmentの存在を確認
+  def machine_assignments_present?
+    update_order_params[:machine_assignments_attributes].present?
+  end
+
+  # MachineAssignmentの更新
+  def update_machine_assignments
+    # ストロングパラメータから machine_assignments_attributes を取得
+    machine_assignments_params = update_order_params[:machine_assignments_attributes]
+
+    # 各 MachineAssignment のパラメータをループ処理
+    machine_assignments_params.each do |_, ma|
+      # machine_id と machine_status_id が存在するか確認。存在しなければ次のループへ
+      next unless ma[:machine_id].present? && ma[:machine_status_id].present?
+
+      # machine_id と machine_status_id を整数に変換
+      machine_id = ma[:machine_id].to_i
+      machine_status_id = ma[:machine_status_id].to_i
+
+      # machine_id または machine_status_id が 0 の場合は無効と判断し、次のループへ
+      next if machine_id.zero? || machine_status_id.zero?
+
+      if ma[:id].present?
+        # 既存のMachineAssignmentをIDで検索
+        assignment = MachineAssignment.find(ma[:id])
+        # machine_id と machine_status_id を更新
+        assignment.update!(machine_id: machine_id, machine_status_id: machine_status_id)
+      else
+        # 新規のMachineAssignmentを各WorkProcessに関連付けて作成
+        @order.work_processes.each do |work_process|
+          work_process.machine_assignments.create!(
+            machine_id: machine_id,
+            machine_status_id: machine_status_id
+          )
+        end
+      end
+    end
+  end
+
+  # Order のその他の詳細を更新
+  def update_order_details
+    update_order = update_order_params.except(:machine_assignments_attributes, :work_processes_attributes)
+    @order.update!(update_order) if update_order.present?
   end
 
   ## 追加: indexアクション用のWorkProcess遅延チェックメソッド

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -48,5 +48,8 @@ class Order < ApplicationRecord
     joins(:work_processes).where(work_processes: { work_process_definition_id: work_process_definition_id }) if work_process_definition_id.present?
   }
 
-
+  # 注文が1週間以内に作成されたかを判定するメソッド
+  def recent?
+    created_at >= 1.weeks.ago
+  end
 end

--- a/app/models/work_process.rb
+++ b/app/models/work_process.rb
@@ -208,5 +208,4 @@ class WorkProcess < ApplicationRecord
       order(:start_date).first
     end
   end
-
 end

--- a/app/views/admin/orders/show.html.erb
+++ b/app/views/admin/orders/show.html.erb
@@ -92,9 +92,9 @@
           <td class="w-2/3 px-4 py-2 text-gray-900 bg-white"><%= @order&.quantity %></td>
         </tr>
         </tr>
-            <tr class="bg-gray-100 border-b">
-            <th class="w-1/3 px-4 py-2 text-center text-gray-700">織機の種類</th>
-            <td class="w-2/3 px-4 py-2 text-gray-900 bg-white"><%= @order&.work_processes&.first.process_estimate&.machine_type.name || 'N/A' %></td>
+        <tr class="bg-gray-100 border-b">
+          <th class="w-1/3 px-4 py-2 text-center text-gray-700">織機の種類</th>
+          <td class="w-2/3 px-4 py-2 text-gray-900 bg-white"><%= @order&.work_processes&.first.process_estimate&.machine_type.name || 'N/A' %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/orders/_form.html.erb
+++ b/app/views/orders/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: @order, local: true) do |form| %>
+<%= form_with(model: @order, url: order_path(@order), method: :patch, local: true) do |form| %>
     <% if @order.errors.any? %>
         <div class="alert alert-danger">
             <h4><%= pluralize(@order.errors.count, "error") %> prohibited this order from being saved:</h4>
@@ -34,7 +34,11 @@
                     </tr>
                     <tr class="bg-gray-100 border-b">
                         <th class="w-1/3 px-4 py-2 text-center text-gray-700"><%= form.label :start_date, "開始日" %></th>
-                        <td class="w-2/3 px-4 py-2 text-gray-900 bg-white"><%= @order&.start_date %></td>
+                        <td class="w-2/3 px-4 py-2 text-gray-900 bg-white"><%= @order&.work_processes&.first&.start_date %></td>
+                    </tr>
+                    <tr class="bg-gray-100 border-b">
+                        <th class="w-1/3 px-4 py-2 text-center text-gray-700">織機の種類</th>
+                        <td class="w-2/3 px-4 py-2 text-gray-900 bg-white"><%= @order&.work_processes&.first&.process_estimate&.machine_type&.name || 'N/A' %></td>
                     </tr>
                 </tbody>
             </table>
@@ -45,8 +49,8 @@
     <section class="mb-12">
         <h2 class="px-4 text-2xl font-semibold text-gray-800 mt-6 mb-6">織機の稼働状況</h2>
         <div class="px-4 overflow-x-auto whitespace-nowrap">
-            <% machine_all = @order.company&.machines %>
-            <% machine_ids = @order.work_processes.joins(:machine_assignments).pluck('machine_assignments.machine_id').uniq %>
+            <% machine_all = @order&.company&.machines %>
+            <% machine_ids = @order&.work_processes.joins(:machine_assignments).pluck('machine_assignments.machine_id').uniq %>
             <% if machine_ids.any? %>
                 <table class="min-w-full border text-left border-gray-300">
                     <thead class="bg-gray-200">
@@ -63,7 +67,13 @@
                             <%= hidden_field_tag "order[machine_assignments_attributes][][id]", machine_assignment&.id %>
                             <tr class="hover:bg-gray-100">
                                 <td class="px-4 py-2 border-b text-gray-900">
-                                    <%= select_tag "order[machine_assignments_attributes][][machine_id]", options_from_collection_for_select(machine_all, :id, :name, machine.id), { prompt: "選択してください", class: "form-control" } %>
+                                    <%= select_tag "order[machine_assignments_attributes][][machine_id]",
+                                        options_for_select(
+                                            machine_all.map { |m| ["#{m.name}（#{m.machine_type.name}）", m.id] },
+                                            machine.id
+                                        ),
+                                        { prompt: "選択してください", class: "form-control" }
+                                    %>
                                 </td>
                                 <td class="px-4 py-2 border-b text-gray-900">
                                     <%= select_tag "order[machine_assignments_attributes][][machine_status_id]", options_from_collection_for_select(MachineStatus.all, :id, :name, current_status), { prompt: "選択してください", class: "form-control" } %>
@@ -85,10 +95,16 @@
                         <tr class="hover:bg-gray-100">
                             <td class="px-4 py-2 border-b text-gray-900">
                                 <% machines = Machine.where(id: machine_ids) %>
-                            <%= select_tag "order[machine_assignments_attributes][0][machine_id]", options_from_collection_for_select(machine_all, :id, :name), { prompt: "織機を選択してください", class: "form-control" } %>
+                                <%= select_tag "order[machine_assignments_attributes][][machine_id]",
+                                    options_for_select(
+                                        machine_all.map { |m| ["#{m.name}（#{m.machine_type.name}）", m.id] },
+                                        nil
+                                    ),
+                                    { prompt: "織機を選択してください", class: "form-control" }
+                                %>
                             </td>
                             <td class="px-4 py-2 border-b text-gray-900">
-                                <%= select_tag "order[machine_assignments_attributes][0][machine_status_id]", options_from_collection_for_select(MachineStatus.all, :id, :name), { prompt: "稼働状況を選択してください", class: "form-control" } %>
+                                <%= select_tag "order[machine_assignments_attributes][][machine_status_id]", options_from_collection_for_select(MachineStatus.all, :id, :name), { prompt: "稼働状況を選択してください", class: "form-control" } %>
                             </td>
                         </tr>
                     </tbody>
@@ -112,27 +128,26 @@
                     </tr>
                 </thead>
                 <tbody>
-                    <% @order.work_processes.each do |wp| %>
-                    <% machine_assignment = wp&.machine_assignments.first %>
-                    <tr class="nested-fields">
-                        <td class="px-4 py-2 border-b text-gray-900">
-                            <%= wp&.work_process_definition&.name %>
-                            <%= hidden_field_tag "order[work_processes][][id]", wp.id %>
-                            <%= hidden_field_tag "order[work_processes][][work_process_definition_id]", wp.work_process_definition_id %>
-                        </td>
-                        <td class="px-4 py-2 border-b text-gray-900">
-                            <%= date_field_tag "order[work_processes][][start_date]", wp.start_date&.strftime('%Y-%m-%d'), class: "block w-full rounded-md bg-white px-4 py-2 text-base text-gray-900 border border-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" %>
-                        </td>
-                        <td class="px-4 py-2 border-b text-gray-900">
-                            <%= date_field_tag "order[work_processes][][factory_estimated_completion_date]", wp.factory_estimated_completion_date&.strftime('%Y-%m-%d'), class: "block w-full rounded-md bg-white px-4 py-2 text-base text-gray-900 border border-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" %>
-                        </td>
-                        <td class="px-4 py-2 border-b text-gray-900">
-                            <%= date_field_tag "order[work_processes][][actual_completion_date]", wp.actual_completion_date&.strftime('%Y-%m-%d'), class: "block w-full rounded-md bg-white px-4 py-2 text-base text-gray-900 border border-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" %>
-                        </td>
-                        <td class="px-4 py-2 border-b text-gray-900">
-                            <%= select_tag "order[work_processes][][work_process_status_id]", options_from_collection_for_select(WorkProcessStatus.all, :id, :name, wp.work_process_status_id), { prompt: "選択してください", class: "form-control" } %>
-                        </td>
-                    </tr>
+                    <%= form.fields_for :work_processes do |wp_form| %>
+                        <tr class="hover:bg-gray-100">
+                            <td class="px-4 py-2 border-b text-gray-900"><%= wp_form.object&.work_process_definition&.name || "N/A" %></td>
+                                <%= wp_form.hidden_field :start_date, value: wp_form.object&.start_date %>
+                            <td class="px-4 py-2 border-b text-gray-900">
+                                <%= wp_form.date_field :start_date, placeholder: "開始日を選択してください", class: "block w-full rounded-md bg-white px-4 py-2 text-base text-gray-900 border border-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" %>
+                            </td>
+                            <td class="px-4 py-2 border-b text-gray-900">
+                                <%= wp_form.date_field :factory_estimated_completion_date, placeholder: "機屋の完了予定日を選択してください", class: "block w-full rounded-md bg-white px-4 py-2 text-base text-gray-900 border border-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" %>
+                            </td>
+                            <td class="px-4 py-2 border-b text-gray-900">
+                                <%= wp_form.date_field :actual_completion_date, placeholder: "機屋の完了日を選択してください", class: "block w-full rounded-md bg-white px-4 py-2 text-base text-gray-900 border border-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" %>
+                            </td>
+                            <td class="px-4 py-2 border-b text-gray-900">
+                                <%= wp_form.collection_select :work_process_status_id,
+                                WorkProcessStatus.all, :id, :name,
+                                selected: wp_form.object&.work_process_status_id,
+                                include_blank: "選択してください" %>
+                            </td>
+                        </tr>
                     <% end %>
                 </tbody>
             </table>

--- a/app/views/orders/_form.html.erb
+++ b/app/views/orders/_form.html.erb
@@ -85,10 +85,10 @@
                         <tr class="hover:bg-gray-100">
                             <td class="px-4 py-2 border-b text-gray-900">
                                 <% machines = Machine.where(id: machine_ids) %>
-                            <%= select_tag "order[machine_assignments_attributes][][machine_id]", options_from_collection_for_select(machine_all, :id, :name), { prompt: "織機を選択してください", class: "form-control" } %>
+                            <%= select_tag "order[machine_assignments_attributes][0][machine_id]", options_from_collection_for_select(machine_all, :id, :name), { prompt: "織機を選択してください", class: "form-control" } %>
                             </td>
                             <td class="px-4 py-2 border-b text-gray-900">
-                                <%= select_tag "order[machine_assignments_attributes][][machine_status_id]", options_from_collection_for_select(MachineStatus.all, :id, :name), { prompt: "稼働状況を選択してください", class: "form-control" } %>
+                                <%= select_tag "order[machine_assignments_attributes][0][machine_status_id]", options_from_collection_for_select(MachineStatus.all, :id, :name), { prompt: "稼働状況を選択してください", class: "form-control" } %>
                             </td>
                         </tr>
                     </tbody>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -2,6 +2,14 @@
 
 <section class="mb-4">
     <div class="py-2 px-4">
+        <% if @orders.any? { |order| order.recent? } %>
+            <p class="text-rose-500 font-semibold">背景が黄色の受注は1週間以内に受注された情報です。</p>
+        <% end %>
+    </div>
+</section>
+
+<section class="mb-4">
+    <div class="py-2 px-4">
         <%= link_to '過去の注文を見る', past_orders_orders_path, class: "inline-block px-4 py-2 font-bold text-gray-700 border border-gray-300 bg-gray-100 rounded hover:bg-sky-600 hover:text-white" %>
     </div>
 </section>
@@ -49,33 +57,33 @@
         <table class="flex-none w-full text-md border text-left rtl:text-right border-gray-300">
             <thead class="uppercase">
                 <tr class="bg-gray-100">
-                    <th scope="col" class="py-2 px-4 border-b">ID</th>
-                    <th scope="col" class="py-2 px-4 border-b">品番</th>
-                    <th scope="col" class="py-2 px-4 border-b">現在の作業工程</th>
-                    <th scope="col" class="py-2 px-4 border-b">ステータス</th>
-                    <th scope="col" class="py-2 px-4 border-b">織機</th>
-                    <th scope="col" class="py-2 px-4 border-b">稼働状況</th>
-                    <th scope="col" class="py-2 px-4 border-b">開始日</th>
-                    <th scope="col" class="py-2 px-4 border-b">完了予定日</th>
-                    <th scope="col" class="py-2 px-4 border-b"></th>
-                    <th scope="col" class="py-2 px-4 border-b"></th>
+                    <th scope="col" class="py-2 px-4 border-b text-gray-700">ID</th>
+                    <th scope="col" class="py-2 px-4 border-b text-gray-700">品番</th>
+                    <th scope="col" class="py-2 px-4 border-b text-gray-700">現在の作業工程</th>
+                    <th scope="col" class="py-2 px-4 border-b text-gray-700">ステータス</th>
+                    <th scope="col" class="py-2 px-4 border-b text-gray-700">織機</th>
+                    <th scope="col" class="py-2 px-4 border-b text-gray-700">稼働状況</th>
+                    <th scope="col" class="py-2 px-4 border-b text-gray-700">開始日</th>
+                    <th scope="col" class="py-2 px-4 border-b text-gray-700">完了予定日</th>
+                    <th scope="col" class="py-2 px-4 border-b text-gray-700"></th>
+                    <th scope="col" class="py-2 px-4 border-b text-gray-700"></th>
                 </tr>
             </thead>
             <tbody>
                 <% @orders.each do |order| %>
-                <tr class="hover:bg-gray-50">
-                    <td scope="row" class="py-2 px-4 border-b"><%= order&.id %></td>
-                    <td scope="row" class="py-2 px-4 border-b"><%= order&.product_number&.number %></td>
-                    <td class="py-2 px-4 border-b"><%= work_process_name(order) %></td>
-                    <td class="py-2 px-4 border-b"><%= work_process_status(order) %></td>
-                    <td class="py-2 px-4 border-b"><%= order&.latest_machine_assignment&.machine&.name || 'N/A' %></td>
-                    <td class="py-2 px-4 border-b"><%= order&.latest_machine_assignment&.machine_status&.name || 'N/A' %></td>
-                    <td class="py-2 px-4 border-b"><%= work_process_start_date(order) %></td>
-                    <td class="py-2 px-4 border-b"><%= work_process_factory_estimated_completion_date(order) %></td>
-                    <td class="py-2 px-4 border-b">
+                <tr class="<%= 'bg-yellow-200 font-semibold text-gray-700' if order.recent? %>">
+                    <td scope="row" class="py-2 px-4 border-b text-gray-700"><%= order&.id %></td>
+                    <td scope="row" class="py-2 px-4 border-b text-gray-700"><%= order&.product_number&.number %></td>
+                    <td class="py-2 px-4 border-b text-gray-700"><%= work_process_name(order) %></td>
+                    <td class="py-2 px-4 border-b text-gray-700"><%= work_process_status(order) %></td>
+                    <td class="py-2 px-4 border-b text-gray-700"><%= order&.latest_machine_assignment&.machine&.name || 'N/A' %></td>
+                    <td class="py-2 px-4 border-b text-gray-700"><%= order&.latest_machine_assignment&.machine_status&.name || 'N/A' %></td>
+                    <td class="py-2 px-4 border-b text-gray-700"><%= work_process_start_date(order) %></td>
+                    <td class="py-2 px-4 border-b text-gray-700"><%= work_process_factory_estimated_completion_date(order) %></td>
+                    <td class="py-2 px-4 border-b text-gray-700">
                         <%= link_to '詳細', order_path(order), class: "inline-block px-4 py-2 text-white bg-indigo-500 rounded hover:bg-indigo-600" %>
                     </td>
-                    <td class="py-2 px-4 border-b">
+                    <td class="py-2 px-4 border-b text-gray-700">
                         <%= link_to '編集', edit_order_path(order), class: "inline-block px-4 py-2 text-white bg-teal-500 rounded hover:bg-teal-600" %>
                     </td>
                 </tr>

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -22,7 +22,11 @@
                 </tr>
                 <tr class="bg-gray-100 border-b">
                     <th class="w-1/3 px-4 py-2 text-center text-gray-700">開始日</th>
-                    <td class="w-2/3 px-4 py-2 text-gray-900 bg-white"><%= @order&.start_date&.strftime('%Y-%m-%d') || 'N/A' %></td>
+                    <td class="w-2/3 px-4 py-2 text-gray-900 bg-white"><%= @order&.work_processes&.first&.start_date&.strftime('%Y-%m-%d') || 'N/A' %></td>
+                </tr>
+                <tr class="bg-gray-100 border-b">
+                    <th class="w-1/3 px-4 py-2 text-center text-gray-700">織機の種類</th>
+                    <td class="w-2/3 px-4 py-2 text-gray-900 bg-white"><%= @order&.work_processes&.first.process_estimate&.machine_type.name || 'N/A' %></td>
                 </tr>
             </tbody>
         </table>


### PR DESCRIPTION
- 対応済みのタスク一覧
  - 織機の割り当てなしに個別編集が可能（問屋、機屋）
  - 新規受注に色をつける（機屋）
     →条件：Order(created_at) ≥ 1.weeks.ago
  - 織機のselect_tagに織機のタイプを追加（機屋）
     →記載例：A001号機（ドビー）
  - 受注詳細に織機の種類を追加（機屋）
  - 受注編集に織機の種類をテキストで追加（機屋）
  - ホーム画面に織機の割り当てがないときのフラッシュメッセージを表示（機屋）
- issue内容
https://github.com/yuutyan2008/loom_management/issues/77
https://github.com/yuutyan2008/loom_management/issues/78